### PR TITLE
Add parameter to increase/decrease wait time when database is locked

### DIFF
--- a/R/misty.R
+++ b/R/misty.R
@@ -74,12 +74,11 @@ utils::globalVariables("where")
 #' (linear kernel), \code{C = 1}, \code{type = "eps-svr"}.
 #'
 #' \emph{MLP} is an alternative to model each view using a multi-layer perceptron.
-#' The alogorithm is based on \code{\link[RSNNS]{mlp}()} --
+#' The algorithm is based on \code{\link[RSNNS]{mlp}()} --
 #' \code{run_misty(views, model.function = mlp_model)}
 #'
 #' The following parameters are the default configuration: \code{size = c(10)}
 #' (meaning we have 1 hidden layer with 10 units).
-#'
 #'
 #' @param views view composition.
 #' @param sample.id id of the sample.
@@ -102,6 +101,9 @@ utils::globalVariables("where")
 #'     \code{gradient_boosting_model}, \code{bagged_mars_model},
 #'     \code{mars_model}, \code{linear_model},
 #'     \code{svm_model}, \code{mlp_model}.
+#' @param sqlite_timeout The timeout duration (in milliseconds) for SQLite to 
+#'     wait for a database lock to be released before returning an error. Default
+#'     is 1000 milliseconds.
 #' @param ... all additional parameters are passed to the chosen ML model for
 #' training the view-specific models.
 #'
@@ -133,7 +135,7 @@ run_misty <- function(views, sample.id = "sample",
                       results.db = paste0(sample.id,".sqm"), seed = 42,
                       target.subset = NULL, bypass.intra = FALSE, cv.folds = 10,
                       cv.strict = FALSE, cached = FALSE, append = TRUE,
-                      model.function = random_forest_model,
+                      model.function = random_forest_model, sqlite_timeout = 1000,
                       ...) {
   model.name <- as.character(rlang::enexpr(model.function))
 
@@ -262,7 +264,7 @@ run_misty <- function(views, sample.id = "sample",
     
     sqm <- DBI::dbConnect(RSQLite::SQLite(), db.file)
     
-    RSQLite::sqliteSetBusyHandler(sqm, 250)
+    RSQLite::sqliteSetBusyHandler(sqm, sqlite_timeout)
     
     to.write <- data.frame(
       target = target, sample = sample.id,

--- a/man/run_misty.Rd
+++ b/man/run_misty.Rd
@@ -16,6 +16,7 @@ run_misty(
   cached = FALSE,
   append = TRUE,
   model.function = random_forest_model,
+  sqlite_timeout = 1000,
   ...
 )
 }
@@ -51,6 +52,10 @@ model is \code{random_forest_model}. Other models included in mistyR are
 \code{gradient_boosting_model}, \code{bagged_mars_model},
 \code{mars_model}, \code{linear_model},
 \code{svm_model}, \code{mlp_model}.}
+
+\item{sqlite_timeout}{The timeout duration (in milliseconds) for SQLite to 
+wait for a database lock to be released before returning an error. Default
+is 1000 milliseconds.}
 
 \item{...}{all additional parameters are passed to the chosen ML model for
 training the view-specific models.}
@@ -116,7 +121,7 @@ The following parameters are the default configuration: \code{kernel = "vanillad
 (linear kernel), \code{C = 1}, \code{type = "eps-svr"}.
 
 \emph{MLP} is an alternative to model each view using a multi-layer perceptron.
-The alogorithm is based on \code{\link[RSNNS]{mlp}()} --
+The algorithm is based on \code{\link[RSNNS]{mlp}()} --
 \code{run_misty(views, model.function = mlp_model)}
 
 The following parameters are the default configuration: \code{size = c(10)}


### PR DESCRIPTION
This seems to work on my side: no more `database is locked` error when the timeout parameter is high. It's a maximal time spent before throwing an error and not a wait time before retry so increasing the default value is not really affecting runtime (~1% on my test data).